### PR TITLE
Don't accept empty replies.

### DIFF
--- a/multidns.py
+++ b/multidns.py
@@ -88,7 +88,7 @@ def IsAcceptable(reply):
         return False
     else:
         if result == None:
-            return None
+            return False
 
     return not bool(re.match(OPTIONS.invalid_resolve, str(result)))
 

--- a/multidns.py
+++ b/multidns.py
@@ -81,12 +81,16 @@ def EncryptDNSRecord(record):
 
 def IsAcceptable(reply):
     global OPTIONS
+
     try:
-        #return reply.get_a().rdata != A("10.10.34.34")
-        return not bool(re.match(OPTIONS.invalid_resolve,
-                                 str(reply.get_a().rdata)))
-    except:
-        return True
+        result = reply.get_a().rdata
+    except AttributeError:
+        return False
+    else:
+        if result == None:
+            return None
+
+    return not bool(re.match(OPTIONS.invalid_resolve, str(result)))
 
 def request_send(self, dest, port = 53, tcp = False, timeout = None, \
                  bind_address = None):


### PR DESCRIPTION
Apparently, on certain occasions we were receiving empty replies,
which was casted into string and matched against the invalid
pattern. Obviously the string 'None' won't match and we'd accept the
result, which is wrong.

We now check for `None` and don't accept it.